### PR TITLE
Fixed: Display of the Meta core exclusive proxy.

### DIFF
--- a/ClashX/Models/ClashProxy.swift
+++ b/ClashX/Models/ClashProxy.swift
@@ -23,8 +23,10 @@ enum ClashProxyType: String, Codable {
     case snell = "Snell"
     case trojan = "Trojan"
     case relay = "Relay"
+    case hysteria = "Hysteria"
+    case vless = "Vless"
     case unknown = "Unknown"
-
+    
     static let proxyGroups: [ClashProxyType] = [.select, .urltest, .fallback, .loadBalance]
 
     var isAutoGroup: Bool {


### PR DESCRIPTION
config 使用 Meta 核心独有的代理时，菜单栏图标选项中无法显示和选择。